### PR TITLE
Add SQL export option to data importer

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -11,16 +11,18 @@ class DashboardController extends Controller
 {
 	public function index()
 	{
-		$stats = [
-			'total_pegawai' => Pegawai::count(),
-			'total_pelatihan' => Pelatihan::count(),
-			'total_jp' => Pelatihan::sum('jp'),
-			'rata_progress' => Pegawai::avg('jp_tercapai'),
-		];
+        $stats = [
+                'total_pegawai' => Pegawai::count(),
+                'total_pelatihan' => Pelatihan::count(),
+                'total_jp' => Pelatihan::sum('jp'),
+                'rata_progress' => (float) Pegawai::selectRaw('AVG(CASE WHEN jp_target > 0 THEN (jp_tercapai / jp_target) * 100 ELSE 0 END) as rata')->value('rata') ?? 0,
+        ];
 
-		$pelatihanByJenis = Pelatihan::select('jenis_pelatihan', DB::raw('count(*) as total'))
-			->groupBy('jenis_pelatihan')
-			->get();
+        $pelatihanByJenis = Pelatihan::leftJoin('jenis_pelatihans', 'pelatihans.jenis_pelatihan_id', '=', 'jenis_pelatihans.id')
+                ->selectRaw('COALESCE(jenis_pelatihans.nama, "Tidak Terdefinisi") as jenis_pelatihan, COUNT(pelatihans.id) as total')
+                ->groupBy('jenis_pelatihan')
+                ->orderBy('jenis_pelatihan')
+                ->get();
 
 		$progressPegawai = Pegawai::select('nama_lengkap', 'jp_target', 'jp_tercapai')
 			->orderByDesc('jp_tercapai')

--- a/app/Models/JenisPelatihan.php
+++ b/app/Models/JenisPelatihan.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class JenisPelatihan extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'kode',
+        'nama',
+        'kategori',
+        'deskripsi',
+        'target_peserta',
+        'durasi_standar',
+        'sertifikasi',
+    ];
+
+    protected $casts = [
+        'sertifikasi' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function pelatihans(): HasMany
+    {
+        return $this->hasMany(Pelatihan::class);
+    }
+}

--- a/app/Models/Pegawai.php
+++ b/app/Models/Pegawai.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Pegawai extends Model
 {
@@ -18,22 +19,39 @@ class Pegawai extends Model
         'status',
         'tanggal_pengangkatan',
         'keterangan',
+        'email',
+        'telepon',
         'jp_target',
         'jp_tercapai'
     ];
 
     protected $casts = [
         'tanggal_pengangkatan' => 'date',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+        'jp_target' => 'integer',
+        'jp_tercapai' => 'integer',
     ];
 
-    public function pelatihans()
+    public function pelatihans(): HasMany
     {
         return $this->hasMany(Pelatihan::class);
+    }
+
+    public function jpTargets(): HasMany
+    {
+        return $this->hasMany(PegawaiJpTarget::class);
     }
 
     public function getPersentaseProgressAttribute()
     {
         if ($this->jp_target == 0) return 0;
         return min(100, ($this->jp_tercapai / $this->jp_target) * 100);
+    }
+
+    public function getKontakLengkapAttribute(): ?string
+    {
+        $parts = array_filter([$this->email, $this->telepon]);
+        return empty($parts) ? null : implode(' / ', $parts);
     }
 }

--- a/app/Models/PegawaiJpTarget.php
+++ b/app/Models/PegawaiJpTarget.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PegawaiJpTarget extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'pegawai_id',
+        'tahun',
+        'jp_target',
+        'jp_tercapai',
+    ];
+
+    protected $casts = [
+        'tahun' => 'integer',
+        'jp_target' => 'integer',
+        'jp_tercapai' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function pegawai(): BelongsTo
+    {
+        return $this->belongsTo(Pegawai::class);
+    }
+}

--- a/app/Models/Pelatihan.php
+++ b/app/Models/Pelatihan.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Pelatihan extends Model
 {
@@ -13,6 +14,7 @@ class Pelatihan extends Model
         'pegawai_id',
         'nama_pelatihan',
         'jenis_pelatihan',
+        'jenis_pelatihan_id',
         'penyelenggara',
         'tempat',
         'tanggal_mulai',
@@ -23,14 +25,58 @@ class Pelatihan extends Model
         'deskripsi'
     ];
 
-    // Tidak menggunakan date casting karena format tanggal bervariasi dalam JSON
-    // protected $casts = [
-    //     'tanggal_mulai' => 'date',
-    //     'tanggal_selesai' => 'date',
-    // ];
+    protected $casts = [
+        'tanggal_mulai' => 'date',
+        'tanggal_selesai' => 'date',
+        'jp' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
 
-    public function pegawai()
+    protected $appends = ['jenis_pelatihan'];
+
+    public function pegawai(): BelongsTo
     {
         return $this->belongsTo(Pegawai::class);
+    }
+
+    public function jenisPelatihan(): BelongsTo
+    {
+        return $this->belongsTo(JenisPelatihan::class);
+    }
+
+    public function getJenisPelatihanAttribute(): ?string
+    {
+        if ($this->relationLoaded('jenisPelatihan')) {
+            return $this->getRelation('jenisPelatihan')?->nama;
+        }
+
+        return $this->jenisPelatihan()->value('nama');
+    }
+
+    public function setJenisPelatihanAttribute($value): void
+    {
+        if (is_null($value) || $value === '') {
+            $this->attributes['jenis_pelatihan_id'] = null;
+            return;
+        }
+
+        if (is_numeric($value)) {
+            $this->attributes['jenis_pelatihan_id'] = (int) $value;
+            return;
+        }
+
+        $jenis = JenisPelatihan::firstOrCreate([
+            'nama' => $value,
+        ]);
+
+        $this->attributes['jenis_pelatihan_id'] = $jenis->id;
+    }
+
+    public function scopeOfJenis($query, string $namaJenis)
+    {
+        return $query->whereHas('jenisPelatihan', function ($subQuery) use ($namaJenis) {
+            $subQuery->where('nama', $namaJenis);
+        });
     }
 }

--- a/tools/data_importer/README.md
+++ b/tools/data_importer/README.md
@@ -1,0 +1,120 @@
+# SIDIKLAT Data Importer
+
+Toolkit untuk mengimpor data pelatihan ke aplikasi SIDIKLAT dari dua sumber utama:
+
+1. **Berkas Excel** yang berisi daftar pelatihan beserta tautan sertifikat.
+2. **Portal SIMPEG BKPP Kota Banjarbaru** yang memerlukan proses login untuk mengambil riwayat diklat.
+
+## Struktur
+
+```
+tools/data_importer/
+├── data_importer/
+│   ├── __init__.py
+│   ├── __main__.py
+│   ├── certificate_downloader.py
+│   ├── cli.py
+│   ├── config.py
+│   ├── db.py
+│   ├── excel_loader.py
+│   ├── models.py
+│   ├── simpeg_scraper.py
+│   └── utils.py
+├── README.md
+└── requirements.txt
+```
+
+## Instalasi
+
+1. Buat dan aktifkan virtual environment Python 3.10+.
+2. Install dependensi:
+
+   ```bash
+   pip install -r tools/data_importer/requirements.txt
+   playwright install chromium
+   ```
+
+3. Salin variabel koneksi database dan kredensial SIMPEG ke environment. Contoh menggunakan file `.env` pada root proyek Laravel. Variabel database hanya diperlukan jika Anda ingin langsung menulis ke database, bukan ketika menghasilkan berkas `.sql`:
+
+   ```dotenv
+   SIDIKLAT_DB_HOST=127.0.0.1
+   SIDIKLAT_DB_PORT=3306
+   SIDIKLAT_DB_NAME=sidiklat
+   SIDIKLAT_DB_USER=root
+   SIDIKLAT_DB_PASSWORD=secret
+
+   SIMPEG_BASE_URL=https://simpeg.bkpp.banjarbarukota.go.id
+   SIMPEG_USERNAME=isi_username
+   SIMPEG_PASSWORD=isi_password
+   SIMPEG_HEADLESS=true
+
+   SIDIKLAT_CERTIFICATE_ROOT=storage/app/public/sertifikat
+   ```
+
+   Secara default berkas sertifikat akan ditempatkan di `storage/app/public/sertifikat` sehingga Laravel dapat melayaninya melalui disk `public`.
+
+## Penggunaan
+
+Jalankan CLI dengan perintah berikut dari root repository:
+
+```bash
+python -m data_importer --help
+```
+
+### Impor dari Excel
+
+```bash
+python -m data_importer import-excel data/daftar_pelatihan.xlsx --sheet "Sheet1"
+```
+
+Kolom yang dikenali secara default:
+
+- `nama`
+- `nip`
+- `jabatan`
+- `unit_kerja`
+- `nama_pelatihan`
+- `jenis_pelatihan`
+- `penyelenggara`
+- `tempat`
+- `tanggal_mulai`
+- `tanggal_selesai`
+- `jp`
+- `sertifikat_url`
+- `keterangan`
+
+Sertifikat akan otomatis diunduh dan dinamai ulang secara ringkas.
+
+Untuk menghasilkan skrip SQL tanpa menyentuh database:
+
+```bash
+python -m data_importer import-excel data/daftar_pelatihan.xlsx --sheet "Sheet1" --sql-output output/pelatihan_excel.sql
+```
+
+### Impor dari SIMPEG
+
+```bash
+python -m data_importer import-simpeg --categories kepemimpinan fungsional teknis
+```
+
+Tambahkan `--sql-output` agar seluruh hasil scraping disusun sebagai pernyataan SQL:
+
+```bash
+python -m data_importer import-simpeg --categories kepemimpinan fungsional teknis --sql-output output/pelatihan_simpeg.sql
+```
+
+Perintah di atas akan:
+
+1. Login ke SIMPEG menggunakan kredensial environment.
+2. Mengambil daftar pegawai pada halaman pencarian.
+3. Membuka halaman detail masing-masing pegawai.
+4. Men-scrape tabel diklat kepemimpinan, fungsional, dan teknis.
+5. Mengunduh berkas sertifikat dan menyimpannya di `storage/app/public/sertifikat`.
+6. Menyimpan/menyinkronkan data ke tabel `pegawais`, `jenis_pelatihans`, dan `pelatihans`.
+
+## Catatan Teknis
+
+- Script menyamakan jenis pelatihan berdasarkan kategori tab di SIMPEG. Nama jenis dapat diubah melalui konstanta `CATEGORY_LABELS` jika diperlukan.
+- Data JP (`jp_tercapai`) pegawai akan disesuaikan secara otomatis setiap kali pelatihan baru ditambahkan atau diperbarui.
+- Untuk keamanan, kredensial SIMPEG tidak disimpan di dalam kode dan harus disediakan melalui environment.
+- Jika situs SIMPEG mengubah struktur HTML, update selektor pada `simpeg_scraper.py` mungkin diperlukan.

--- a/tools/data_importer/data_importer/__init__.py
+++ b/tools/data_importer/data_importer/__init__.py
@@ -1,0 +1,10 @@
+"""Utilities for importing SIDIKLAT data from external sources."""
+
+__all__ = [
+    "config",
+    "excel_loader",
+    "certificate_downloader",
+    "db",
+    "simpeg_scraper",
+    "cli",
+]

--- a/tools/data_importer/data_importer/__main__.py
+++ b/tools/data_importer/data_importer/__main__.py
@@ -1,0 +1,5 @@
+from .cli import run
+
+
+if __name__ == "__main__":
+    run()

--- a/tools/data_importer/data_importer/certificate_downloader.py
+++ b/tools/data_importer/data_importer/certificate_downloader.py
@@ -1,0 +1,49 @@
+"""Download helper for pelatihan certificates."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Mapping, Optional
+
+import requests
+
+from .utils import build_certificate_filename, ensure_directory, guess_extension_from_content_type
+
+
+logger = logging.getLogger(__name__)
+
+
+class CertificateDownloader:
+    def __init__(self, root_directory: Path) -> None:
+        self.root_directory = root_directory
+        ensure_directory(self.root_directory)
+
+    def download(
+        self,
+        url: str,
+        nama: str,
+        pelatihan: str,
+        session: Optional[requests.Session] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Optional[Path]:
+        if not url:
+            return None
+
+        client = session or requests.Session()
+
+        response = client.get(url, headers=headers or {}, timeout=60, stream=True)
+        response.raise_for_status()
+
+        extension = guess_extension_from_content_type(response.headers.get("Content-Type"))
+        filename = build_certificate_filename(nama, pelatihan, extension)
+        destination = self.root_directory / filename
+
+        ensure_directory(destination.parent)
+        with destination.open("wb") as handle:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    handle.write(chunk)
+
+        logger.info("Downloaded certificate %s", destination)
+        return destination

--- a/tools/data_importer/data_importer/cli.py
+++ b/tools/data_importer/data_importer/cli.py
@@ -1,0 +1,267 @@
+"""Command line interface for SIDIKLAT data importer."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+
+from .certificate_downloader import CertificateDownloader
+from .config import AppConfig
+from .db import DatabaseClient, database_client
+from .excel_loader import ExcelLoader
+from .models import ExcelTrainingRow, SimpegTrainingRecord
+from .simpeg_scraper import SimpegScraper
+from .sql_writer import SqlScriptBuilder, build_training_sql_block
+
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(help="Import data pegawai dan pelatihan ke SIDIKLAT.")
+
+
+def _store_excel_row(
+    row: ExcelTrainingRow,
+    downloader: CertificateDownloader,
+    certificate_root: Path,
+    client: DatabaseClient | None = None,
+    sql_builder: SqlScriptBuilder | None = None,
+):
+    jenis_nama = row.jenis_pelatihan or "Lainnya"
+
+    sertifikat_path = None
+    sertifikat_sql_path = None
+    if row.sertifikat_url:
+        try:
+            destination = downloader.download(row.sertifikat_url, row.nama, row.nama_pelatihan)
+            sertifikat_path = destination.relative_to(certificate_root.parent)
+            sertifikat_sql_path = sertifikat_path.as_posix()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Gagal mengunduh sertifikat %s: %s", row.sertifikat_url, exc)
+
+    if sql_builder is not None:
+        sql_builder.add_block(
+            build_training_sql_block(
+                pegawai_nama=row.nama,
+                pegawai_nip=row.nip,
+                nama_pelatihan=row.nama_pelatihan,
+                jenis_pelatihan=jenis_nama,
+                penyelenggara=row.penyelenggara,
+                tempat=row.tempat,
+                tanggal_mulai=row.tanggal_mulai,
+                tanggal_selesai=row.tanggal_selesai,
+                jp=row.jp,
+                status="selesai",
+                deskripsi=row.keterangan,
+                sertifikat_path=sertifikat_sql_path,
+                jabatan=row.jabatan,
+                unit_kerja=row.unit_kerja,
+                keterangan=row.keterangan,
+            )
+        )
+        return
+
+    if client is None:
+        raise ValueError("Database client atau SQL builder harus disediakan")
+
+    pegawai = client.upsert_pegawai(
+        nama=row.nama,
+        nip=row.nip,
+        jabatan=row.jabatan,
+        unit_kerja=row.unit_kerja,
+        keterangan=row.keterangan,
+    )
+
+    client.upsert_pelatihan(
+        pegawai_id=pegawai.id,
+        nama_pelatihan=row.nama_pelatihan,
+        jenis_nama=jenis_nama,
+        penyelenggara=row.penyelenggara,
+        tempat=row.tempat,
+        tanggal_mulai=row.tanggal_mulai,
+        tanggal_selesai=row.tanggal_selesai,
+        jp=row.jp or 0,
+        status="selesai",
+        deskripsi=row.keterangan,
+        sertifikat_path=sertifikat_path,
+    )
+
+
+@app.command("import-excel")
+def import_excel(
+    excel_path: Path = typer.Argument(..., exists=True, dir_okay=False, help="Path file Excel sumber."),
+    sheet_name: Optional[str] = typer.Option(None, help="Nama sheet yang akan dibaca."),
+    sql_output: Optional[Path] = typer.Option(
+        None,
+        help="Jika diset, data tidak langsung dimasukkan ke database melainkan ditulis ke file SQL ini.",
+    ),
+) -> None:
+    """Impor data pelatihan dari berkas Excel."""
+
+    config = AppConfig.load()
+    loader = ExcelLoader()
+    downloader = CertificateDownloader(config.storage.certificate_root)
+    certificate_root = config.storage.certificate_root
+
+    rows = loader.load(excel_path, sheet_name=sheet_name)
+    logger.info("Memproses %s baris dari Excel", len(rows))
+
+    if sql_output:
+        builder = SqlScriptBuilder(sql_output)
+        for row in rows:
+            _store_excel_row(row, downloader, certificate_root, sql_builder=builder)
+        output_path = builder.save()
+        logger.info("Skrip SQL tersimpan di %s", output_path)
+    else:
+        with database_client(config.database) as client:
+            for row in rows:
+                _store_excel_row(row, downloader, certificate_root, client=client)
+
+    logger.info("Import Excel selesai.")
+
+
+CATEGORY_LABELS = {
+    "kepemimpinan": "Diklat Kepemimpinan",
+    "fungsional": "Diklat Fungsional",
+    "teknis": "Diklat Teknis",
+}
+
+
+def _store_simpeg_record(
+    record: SimpegTrainingRecord,
+    downloader: CertificateDownloader,
+    certificate_root: Path,
+    session,
+    client: DatabaseClient | None = None,
+    sql_builder: SqlScriptBuilder | None = None,
+):
+    jenis_nama = CATEGORY_LABELS.get(record.kategori, record.kategori.title())
+
+    sertifikat_path = None
+    sertifikat_sql_path = None
+    if record.sertifikat_url:
+        try:
+            destination = downloader.download(
+                record.sertifikat_url,
+                record.pegawai_nama,
+                record.nama_pelatihan or record.induk_diklat or record.kategori,
+                session=session,
+            )
+            sertifikat_path = destination.relative_to(certificate_root.parent)
+            sertifikat_sql_path = sertifikat_path.as_posix()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Gagal mengunduh sertifikat untuk %s: %s", record.nama_pelatihan, exc)
+
+    if sql_builder is not None:
+        sql_builder.add_block(
+            build_training_sql_block(
+                pegawai_nama=record.pegawai_nama,
+                pegawai_nip=record.pegawai_nip,
+                nama_pelatihan=record.nama_pelatihan or record.induk_diklat or "Diklat",
+                jenis_pelatihan=jenis_nama,
+                penyelenggara=record.penyelenggara,
+                tempat=record.tempat,
+                tanggal_mulai=record.tanggal_mulai,
+                tanggal_selesai=record.tanggal_selesai,
+                jp=record.jp,
+                status=record.status,
+                deskripsi=record.nomor_sttp,
+                sertifikat_path=sertifikat_sql_path,
+            )
+        )
+        return
+
+    if client is None:
+        raise ValueError("Database client atau SQL builder harus disediakan")
+
+    pegawai = client.upsert_pegawai(
+        nama=record.pegawai_nama,
+        nip=record.pegawai_nip,
+    )
+
+    client.upsert_pelatihan(
+        pegawai_id=pegawai.id,
+        nama_pelatihan=record.nama_pelatihan or record.induk_diklat or "Diklat",
+        jenis_nama=jenis_nama,
+        penyelenggara=record.penyelenggara,
+        tempat=record.tempat,
+        tanggal_mulai=record.tanggal_mulai,
+        tanggal_selesai=record.tanggal_selesai,
+        jp=record.jp or 0,
+        status=record.status,
+        deskripsi=record.nomor_sttp,
+        sertifikat_path=sertifikat_path,
+    )
+
+
+@app.command("import-simpeg")
+def import_simpeg(
+    username: Optional[str] = typer.Option(None, help="Username SIMPEG. Default dari env SIMPEG_USERNAME."),
+    password: Optional[str] = typer.Option(None, help="Password SIMPEG. Default dari env SIMPEG_PASSWORD."),
+    categories: Optional[List[str]] = typer.Option(
+        None,
+        help="Daftar kategori yang diambil (kepemimpinan, fungsional, teknis).",
+    ),
+    sql_output: Optional[Path] = typer.Option(
+        None,
+        help="Jika diset, hasil scraping ditulis ke file SQL alih-alih langsung ke database.",
+    ),
+) -> None:
+    """Scrape data SIMPEG dan simpan ke database atau file SQL."""
+
+    config = AppConfig.load()
+    username = username or config.simpeg.username
+    password = password or config.simpeg.password
+
+    if not username or not password:
+        raise typer.BadParameter("Username dan password SIMPEG wajib diisi.")
+
+    categories = categories or ["kepemimpinan"]
+
+    with SimpegScraper(
+        config.simpeg.base_url,
+        headless=config.simpeg.headless,
+        download_dir=config.storage.certificate_root,
+    ) as scraper:
+        scraper.login(username, password)
+        session = scraper.build_requests_session()
+        downloader = CertificateDownloader(config.storage.certificate_root)
+
+        pegawai_rows = list(scraper.iter_pegawai_rows())
+        logger.info("Mengambil diklat untuk %s pegawai", len(pegawai_rows))
+
+        if sql_output:
+            builder = SqlScriptBuilder(sql_output)
+            for record in scraper.iter_training_records(pegawai_rows, categories=categories):
+                _store_simpeg_record(
+                    record,
+                    downloader,
+                    config.storage.certificate_root,
+                    session,
+                    sql_builder=builder,
+                )
+            output_path = builder.save()
+            logger.info("Skrip SQL tersimpan di %s", output_path)
+        else:
+            with database_client(config.database) as client:
+                for record in scraper.iter_training_records(pegawai_rows, categories=categories):
+                    _store_simpeg_record(
+                        record,
+                        downloader,
+                        config.storage.certificate_root,
+                        session,
+                        client=client,
+                    )
+
+    logger.info("Import SIMPEG selesai.")
+
+
+def run():  # pragma: no cover - CLI entry point
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/tools/data_importer/data_importer/config.py
+++ b/tools/data_importer/data_importer/config.py
@@ -1,0 +1,74 @@
+"""Configuration helpers for the data importer."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+
+@dataclass(frozen=True)
+class DatabaseConfig:
+    host: str
+    port: int
+    name: str
+    user: str
+    password: str
+
+    @classmethod
+    def from_env(cls) -> "DatabaseConfig":
+        return cls(
+            host=os.getenv("SIDIKLAT_DB_HOST", "127.0.0.1"),
+            port=int(os.getenv("SIDIKLAT_DB_PORT", "3306")),
+            name=os.getenv("SIDIKLAT_DB_NAME", "sidiklat"),
+            user=os.getenv("SIDIKLAT_DB_USER", "root"),
+            password=os.getenv("SIDIKLAT_DB_PASSWORD", ""),
+        )
+
+
+@dataclass(frozen=True)
+class StorageConfig:
+    certificate_root: Path
+
+    @classmethod
+    def from_env(cls) -> "StorageConfig":
+        root = Path(os.getenv("SIDIKLAT_CERTIFICATE_ROOT", "storage/app/public/sertifikat"))
+        return cls(certificate_root=root)
+
+
+@dataclass(frozen=True)
+class SimpegConfig:
+    base_url: str
+    username: Optional[str]
+    password: Optional[str]
+    headless: bool = True
+
+    @classmethod
+    def from_env(cls) -> "SimpegConfig":
+        return cls(
+            base_url=os.getenv("SIMPEG_BASE_URL", "https://simpeg.bkpp.banjarbarukota.go.id"),
+            username=os.getenv("SIMPEG_USERNAME"),
+            password=os.getenv("SIMPEG_PASSWORD"),
+            headless=os.getenv("SIMPEG_HEADLESS", "true").lower() != "false",
+        )
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    database: DatabaseConfig
+    storage: StorageConfig
+    simpeg: SimpegConfig
+
+    @classmethod
+    def load(cls) -> "AppConfig":
+        return cls(
+            database=DatabaseConfig.from_env(),
+            storage=StorageConfig.from_env(),
+            simpeg=SimpegConfig.from_env(),
+        )

--- a/tools/data_importer/data_importer/db.py
+++ b/tools/data_importer/data_importer/db.py
@@ -1,0 +1,368 @@
+"""Database helper utilities."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterator, Optional
+
+import mysql.connector
+
+from .config import DatabaseConfig
+from .models import StoredPegawai, StoredPelatihan
+
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseClient:
+    def __init__(self, config: DatabaseConfig) -> None:
+        self.config = config
+        self.connection: Optional[mysql.connector.MySQLConnection] = None
+
+    def connect(self) -> None:
+        if self.connection and self.connection.is_connected():
+            return
+        self.connection = mysql.connector.connect(
+            host=self.config.host,
+            port=self.config.port,
+            user=self.config.user,
+            password=self.config.password,
+            database=self.config.name,
+            autocommit=False,
+        )
+
+    def close(self) -> None:
+        if self.connection is not None and self.connection.is_connected():
+            self.connection.close()
+            self.connection = None
+
+    def __enter__(self) -> "DatabaseClient":
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if exc:
+            if self.connection:
+                self.connection.rollback()
+        else:
+            if self.connection:
+                self.connection.commit()
+        self.close()
+
+    def _get_cursor(self):
+        if not self.connection:
+            raise RuntimeError("Database connection has not been established")
+        return self.connection.cursor(dictionary=True)
+
+    def _current_timestamp(self) -> datetime:
+        return datetime.utcnow()
+
+    # Pegawai helpers -------------------------------------------------
+
+    def _find_pegawai(self, *, nip: Optional[str], nama: str) -> Optional[StoredPegawai]:
+        cursor = self._get_cursor()
+        if nip:
+            cursor.execute(
+                "SELECT id, nama_lengkap as nama, nip FROM pegawais WHERE nip = %s LIMIT 1",
+                (nip,),
+            )
+            row = cursor.fetchone()
+            if row:
+                return StoredPegawai(id=row["id"], nama=row["nama"], nip=row["nip"])
+
+        cursor.execute(
+            "SELECT id, nama_lengkap as nama, nip FROM pegawais WHERE nama_lengkap = %s LIMIT 1",
+            (nama,),
+        )
+        row = cursor.fetchone()
+        if row:
+            return StoredPegawai(id=row["id"], nama=row["nama"], nip=row["nip"])
+        return None
+
+    def upsert_pegawai(
+        self,
+        nama: str,
+        nip: Optional[str] = None,
+        jabatan: Optional[str] = None,
+        unit_kerja: Optional[str] = None,
+        pangkat: Optional[str] = None,
+        status: str = "aktif",
+        email: Optional[str] = None,
+        telepon: Optional[str] = None,
+        tanggal_pengangkatan: Optional[date] = None,
+        keterangan: Optional[str] = None,
+    ) -> StoredPegawai:
+        existing = self._find_pegawai(nip=nip, nama=nama)
+        cursor = self._get_cursor()
+        timestamp = self._current_timestamp()
+
+        if existing:
+            cursor.execute(
+                """
+                UPDATE pegawais
+                   SET nama_lengkap = %s,
+                       nip = %s,
+                       jabatan = COALESCE(%s, jabatan),
+                       unit_kerja = COALESCE(%s, unit_kerja),
+                       pangkat_golongan = COALESCE(%s, pangkat_golongan),
+                       status = COALESCE(%s, status),
+                       email = COALESCE(%s, email),
+                       telepon = COALESCE(%s, telepon),
+                       tanggal_pengangkatan = COALESCE(%s, tanggal_pengangkatan),
+                       keterangan = COALESCE(%s, keterangan),
+                       updated_at = %s
+                 WHERE id = %s
+                """,
+                (
+                    nama,
+                    nip,
+                    jabatan,
+                    unit_kerja,
+                    pangkat,
+                    status,
+                    email,
+                    telepon,
+                    tanggal_pengangkatan,
+                    keterangan,
+                    timestamp,
+                    existing.id,
+                ),
+            )
+            return existing
+
+        cursor.execute(
+            """
+            INSERT INTO pegawais
+                (nama_lengkap, nip, jabatan, unit_kerja, pangkat_golongan, status, email, telepon, tanggal_pengangkatan, keterangan, jp_target, jp_tercapai, created_at, updated_at)
+            VALUES
+                (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                nama,
+                nip,
+                jabatan,
+                unit_kerja,
+                pangkat,
+                status,
+                email,
+                telepon,
+                tanggal_pengangkatan,
+                keterangan,
+                0,
+                0,
+                timestamp,
+                timestamp,
+            ),
+        )
+        pegawai_id = cursor.lastrowid
+        logger.info("Created pegawai %s (%s)", nama, pegawai_id)
+        return StoredPegawai(id=pegawai_id, nama=nama, nip=nip)
+
+    # Jenis Pelatihan -------------------------------------------------
+
+    def ensure_jenis_pelatihan(self, nama: str) -> int:
+        if not nama:
+            raise ValueError("Nama jenis pelatihan tidak boleh kosong")
+        cursor = self._get_cursor()
+        cursor.execute(
+            "SELECT id FROM jenis_pelatihans WHERE nama = %s LIMIT 1",
+            (nama,),
+        )
+        row = cursor.fetchone()
+        if row:
+            return row["id"]
+
+        cursor.execute(
+            """
+            INSERT INTO jenis_pelatihans (nama, created_at, updated_at)
+            VALUES (%s, %s, %s)
+            """,
+            (nama, self._current_timestamp(), self._current_timestamp()),
+        )
+        jenis_id = cursor.lastrowid
+        logger.info("Created jenis pelatihan %s (%s)", nama, jenis_id)
+        return jenis_id
+
+    # Pelatihan -------------------------------------------------------
+
+    def _find_pelatihan(self, pegawai_id: int, nama_pelatihan: str, tanggal_mulai: Optional[date], tanggal_selesai: Optional[date]) -> Optional[StoredPelatihan]:
+        cursor = self._get_cursor()
+        cursor.execute(
+            """
+            SELECT id, pegawai_id, nama_pelatihan, tanggal_mulai, tanggal_selesai, jp, sertifikat_path
+              FROM pelatihans
+             WHERE pegawai_id = %s
+               AND nama_pelatihan = %s
+               AND (tanggal_mulai = %s OR (tanggal_mulai IS NULL AND %s IS NULL))
+               AND (tanggal_selesai = %s OR (tanggal_selesai IS NULL AND %s IS NULL))
+             LIMIT 1
+            """,
+            (pegawai_id, nama_pelatihan, tanggal_mulai, tanggal_mulai, tanggal_selesai, tanggal_selesai),
+        )
+        row = cursor.fetchone()
+        if row:
+            return StoredPelatihan(
+                id=row["id"],
+                pegawai_id=row["pegawai_id"],
+                nama_pelatihan=row["nama_pelatihan"],
+                tanggal_mulai=row["tanggal_mulai"],
+                tanggal_selesai=row["tanggal_selesai"],
+                jp=row["jp"],
+                sertifikat_path=Path(row["sertifikat_path"]) if row["sertifikat_path"] else None,
+            )
+        return None
+
+    def upsert_pelatihan(
+        self,
+        pegawai_id: int,
+        nama_pelatihan: str,
+        jenis_nama: Optional[str],
+        penyelenggara: Optional[str],
+        tempat: Optional[str],
+        tanggal_mulai: Optional[date],
+        tanggal_selesai: Optional[date],
+        jp: Optional[int],
+        status: str,
+        deskripsi: Optional[str] = None,
+        sertifikat_path: Optional[Path] = None,
+    ) -> StoredPelatihan:
+        cursor = self._get_cursor()
+        jenis_id = self.ensure_jenis_pelatihan(jenis_nama) if jenis_nama else None
+        existing = self._find_pelatihan(pegawai_id, nama_pelatihan, tanggal_mulai, tanggal_selesai)
+        timestamp = self._current_timestamp()
+
+        sertifikat_value = str(sertifikat_path) if sertifikat_path else None
+
+        if existing:
+            previous_jp = existing.jp or 0
+            cursor.execute(
+                """
+                SELECT status, jp FROM pelatihans WHERE id = %s
+                """,
+                (existing.id,),
+            )
+            status_row = cursor.fetchone()
+            old_status = status_row["status"] if status_row else None
+            old_jp = status_row["jp"] if status_row else previous_jp
+
+            cursor.execute(
+                """
+                UPDATE pelatihans
+                   SET jenis_pelatihan_id = %s,
+                       penyelenggara = %s,
+                       tempat = %s,
+                       tanggal_mulai = %s,
+                       tanggal_selesai = %s,
+                       jp = %s,
+                       status = %s,
+                       deskripsi = %s,
+                       sertifikat_path = %s,
+                       updated_at = %s
+                 WHERE id = %s
+                """,
+                (
+                    jenis_id,
+                    penyelenggara,
+                    tempat,
+                    tanggal_mulai,
+                    tanggal_selesai,
+                    jp,
+                    status,
+                    deskripsi,
+                    sertifikat_value,
+                    timestamp,
+                    existing.id,
+                ),
+            )
+
+            self._update_jp_progress(pegawai_id, old_status, old_jp, status, jp)
+            return StoredPelatihan(
+                id=existing.id,
+                pegawai_id=pegawai_id,
+                nama_pelatihan=nama_pelatihan,
+                tanggal_mulai=tanggal_mulai,
+                tanggal_selesai=tanggal_selesai,
+                jp=jp,
+                sertifikat_path=sertifikat_path,
+            )
+
+        cursor.execute(
+            """
+            INSERT INTO pelatihans
+                (pegawai_id, nama_pelatihan, jenis_pelatihan_id, penyelenggara, tempat, tanggal_mulai, tanggal_selesai, jp, status, sertifikat_path, deskripsi, created_at, updated_at)
+            VALUES
+                (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                pegawai_id,
+                nama_pelatihan,
+                jenis_id,
+                penyelenggara,
+                tempat,
+                tanggal_mulai,
+                tanggal_selesai,
+                jp,
+                status,
+                sertifikat_value,
+                deskripsi,
+                timestamp,
+                timestamp,
+            ),
+        )
+        pelatihan_id = cursor.lastrowid
+        self._update_jp_progress(pegawai_id, None, 0, status, jp)
+        logger.info("Stored pelatihan %s untuk pegawai %s", pelatihan_id, pegawai_id)
+        return StoredPelatihan(
+            id=pelatihan_id,
+            pegawai_id=pegawai_id,
+            nama_pelatihan=nama_pelatihan,
+            tanggal_mulai=tanggal_mulai,
+            tanggal_selesai=tanggal_selesai,
+            jp=jp,
+            sertifikat_path=sertifikat_path,
+        )
+
+    def _update_jp_progress(
+        self,
+        pegawai_id: int,
+        old_status: Optional[str],
+        old_jp: Optional[int],
+        new_status: Optional[str],
+        new_jp: Optional[int],
+    ) -> None:
+        adjust = 0
+        if old_status == "selesai" and old_jp:
+            adjust -= old_jp
+        if new_status == "selesai" and new_jp:
+            adjust += new_jp
+        if adjust == 0:
+            return
+        cursor = self._get_cursor()
+        cursor.execute(
+            """
+            UPDATE pegawais
+               SET jp_tercapai = GREATEST(0, COALESCE(jp_tercapai, 0) + %s),
+                   updated_at = %s
+             WHERE id = %s
+            """,
+            (adjust, self._current_timestamp(), pegawai_id),
+        )
+
+
+@contextmanager
+def database_client(config: DatabaseConfig) -> Iterator[DatabaseClient]:
+    client = DatabaseClient(config)
+    try:
+        client.connect()
+        yield client
+        if client.connection:
+            client.connection.commit()
+    except Exception:
+        if client.connection:
+            client.connection.rollback()
+        raise
+    finally:
+        client.close()

--- a/tools/data_importer/data_importer/excel_loader.py
+++ b/tools/data_importer/data_importer/excel_loader.py
@@ -1,0 +1,112 @@
+"""Load training data from Excel workbooks."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from openpyxl import load_workbook
+
+from .models import ExcelTrainingRow
+
+
+DEFAULT_COLUMN_MAP: Dict[str, str] = {
+    "nama": "nama",
+    "nip": "nip",
+    "jabatan": "jabatan",
+    "unit_kerja": "unit_kerja",
+    "nama_pelatihan": "nama_pelatihan",
+    "jenis_pelatihan": "jenis_pelatihan",
+    "penyelenggara": "penyelenggara",
+    "tempat": "tempat",
+    "tanggal_mulai": "tanggal_mulai",
+    "tanggal_selesai": "tanggal_selesai",
+    "jp": "jp",
+    "sertifikat_url": "sertifikat_url",
+    "keterangan": "keterangan",
+}
+
+
+def _normalize_header(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.strip().lower().replace(" ", "_")
+
+
+def _parse_date(value) -> Optional[datetime.date]:
+    if value in (None, "", "-"):
+        return None
+
+    if isinstance(value, datetime):
+        return value.date()
+
+    if hasattr(value, "date"):
+        return value.date()
+
+    for fmt in ("%Y-%m-%d", "%d-%m-%Y", "%d/%m/%Y", "%d %B %Y"):
+        try:
+            return datetime.strptime(str(value), fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_int(value) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+class ExcelLoader:
+    """Loader that converts workbook rows to :class:`ExcelTrainingRow`."""
+
+    def __init__(self, column_map: Optional[Dict[str, str]] = None) -> None:
+        self.column_map = column_map or DEFAULT_COLUMN_MAP
+
+    def load(self, path: Path, sheet_name: Optional[str] = None) -> List[ExcelTrainingRow]:
+        workbook = load_workbook(filename=path, data_only=True)
+        sheet = workbook[sheet_name] if sheet_name else workbook.active
+
+        header_row = next(sheet.iter_rows(min_row=1, max_row=1, values_only=True))
+        header_index = {
+            _normalize_header(header): idx for idx, header in enumerate(header_row) if header is not None
+        }
+
+        rows: List[ExcelTrainingRow] = []
+        for raw_row in sheet.iter_rows(min_row=2, values_only=True):
+            data = {}
+            for field, header_name in self.column_map.items():
+                key = _normalize_header(header_name)
+                if key not in header_index:
+                    continue
+                data[field] = raw_row[header_index[key]]
+
+            if not data.get("nama") and not data.get("nama_pelatihan"):
+                continue
+
+            rows.append(
+                ExcelTrainingRow(
+                    nama=str(data.get("nama") or "").strip(),
+                    nip=str(data.get("nip") or "").strip() or None,
+                    jabatan=(str(data.get("jabatan")).strip() if data.get("jabatan") else None),
+                    unit_kerja=(str(data.get("unit_kerja")).strip() if data.get("unit_kerja") else None),
+                    nama_pelatihan=str(data.get("nama_pelatihan") or "").strip(),
+                    jenis_pelatihan=(str(data.get("jenis_pelatihan")).strip() if data.get("jenis_pelatihan") else None),
+                    penyelenggara=(str(data.get("penyelenggara")).strip() if data.get("penyelenggara") else None),
+                    tempat=(str(data.get("tempat")).strip() if data.get("tempat") else None),
+                    tanggal_mulai=_parse_date(data.get("tanggal_mulai")),
+                    tanggal_selesai=_parse_date(data.get("tanggal_selesai")),
+                    jp=_parse_int(data.get("jp")),
+                    sertifikat_url=(str(data.get("sertifikat_url")).strip() if data.get("sertifikat_url") else None),
+                    keterangan=(str(data.get("keterangan")).strip() if data.get("keterangan") else None),
+                )
+            )
+        return rows
+
+    def load_iter(self, path: Path, sheet_name: Optional[str] = None) -> Iterable[ExcelTrainingRow]:
+        for row in self.load(path, sheet_name):
+            yield row

--- a/tools/data_importer/data_importer/models.py
+++ b/tools/data_importer/data_importer/models.py
@@ -1,0 +1,63 @@
+"""Data structures shared by importer components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class ExcelTrainingRow:
+    nama: str
+    nip: Optional[str]
+    jabatan: Optional[str]
+    unit_kerja: Optional[str]
+    nama_pelatihan: str
+    jenis_pelatihan: Optional[str]
+    penyelenggara: Optional[str]
+    tempat: Optional[str]
+    tanggal_mulai: Optional[date]
+    tanggal_selesai: Optional[date]
+    jp: Optional[int]
+    sertifikat_url: Optional[str]
+    keterangan: Optional[str] = None
+
+
+@dataclass
+class SimpegTrainingRecord:
+    pegawai_id: int
+    pegawai_nama: str
+    pegawai_nip: Optional[str]
+    kategori: str
+    nama_pelatihan: str
+    induk_diklat: Optional[str]
+    tempat: Optional[str]
+    penyelenggara: Optional[str]
+    tanggal_mulai: Optional[date]
+    tanggal_selesai: Optional[date]
+    jp: Optional[int]
+    nomor_sttp: Optional[str]
+    tanggal_sttp: Optional[date]
+    sertifikat_url: Optional[str]
+    sertifikat_path: Optional[Path] = None
+    status: str = "selesai"
+
+
+@dataclass
+class StoredPegawai:
+    id: int
+    nama: str
+    nip: Optional[str]
+
+
+@dataclass
+class StoredPelatihan:
+    id: int
+    pegawai_id: int
+    nama_pelatihan: str
+    tanggal_mulai: Optional[date]
+    tanggal_selesai: Optional[date]
+    jp: Optional[int]
+    sertifikat_path: Optional[Path]

--- a/tools/data_importer/data_importer/simpeg_scraper.py
+++ b/tools/data_importer/data_importer/simpeg_scraper.py
@@ -1,0 +1,264 @@
+"""Scraper for SIMPEG diklat data using Playwright."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional
+
+import requests
+from playwright.sync_api import Browser, BrowserContext, Error as PlaywrightError, Page, sync_playwright
+
+from .models import SimpegTrainingRecord
+from .utils import ensure_directory
+
+
+logger = logging.getLogger(__name__)
+
+
+TRAINING_TABS = {
+    "kepemimpinan": {
+        "tab_selector": "ul#demo-pill-nav a:has-text('Diklat Kepemimpinan')",
+        "container": "#tabelkepemimpinan",
+        "column_map": {
+            "induk_diklat": 1,
+            "nama_pelatihan": 2,
+            "tempat": 3,
+            "penyelenggara": 4,
+            "tanggal_mulai": 5,
+            "tanggal_selesai": 6,
+            "jp": 7,
+            "nomor_sttp": 8,
+            "tanggal_sttp": 9,
+        },
+    },
+    "fungsional": {
+        "tab_selector": "ul#demo-pill-nav a:has-text('Diklat Fungsional')",
+        "container": "#tabelfungsional",
+        "column_map": {
+            "nama_pelatihan": 1,
+            "tempat": 2,
+            "penyelenggara": 3,
+            "tanggal_mulai": 4,
+            "tanggal_selesai": 5,
+            "jp": 6,
+            "nomor_sttp": 7,
+            "tanggal_sttp": 8,
+        },
+    },
+    "teknis": {
+        "tab_selector": "ul#demo-pill-nav a:has-text('Diklat Teknis')",
+        "container": "#tabelteknis",
+        "column_map": {
+            "nama_pelatihan": 1,
+            "tempat": 2,
+            "penyelenggara": 3,
+            "tanggal_mulai": 4,
+            "tanggal_selesai": 5,
+            "jp": 6,
+            "nomor_sttp": 7,
+            "tanggal_sttp": 8,
+        },
+    },
+}
+
+
+class SimpegScraper:
+    def __init__(self, base_url: str, headless: bool = True, download_dir: Optional[Path] = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.headless = headless
+        self.download_dir = download_dir or Path("downloads")
+        ensure_directory(self.download_dir)
+        self._play = None
+        self.browser: Optional[Browser] = None
+        self.context: Optional[BrowserContext] = None
+        self.page: Optional[Page] = None
+
+    def __enter__(self) -> "SimpegScraper":
+        self._play = sync_playwright().start()
+        self.browser = self._play.chromium.launch(headless=self.headless)
+        self.context = self.browser.new_context(accept_downloads=True)
+        self.page = self.context.new_page()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.page:
+            self.page.close()
+        if self.context:
+            self.context.close()
+        if self.browser:
+            self.browser.close()
+        if self._play:
+            self._play.stop()
+
+    # Authentication --------------------------------------------------
+
+    def login(self, username: str, password: str) -> None:
+        if not self.page:
+            raise RuntimeError("Scraper not initialised")
+
+        login_url = f"{self.base_url}/simpeg/site/login"
+        self.page.goto(login_url)
+        self.page.fill("#LoginForm_username", username)
+        self.page.fill("#LoginForm_password", password)
+        self.page.click("button[type='submit'], input[type='submit']")
+        self.page.wait_for_load_state("networkidle")
+
+        if "login" in self.page.url.lower():
+            raise PlaywrightError("Gagal login ke SIMPEG, periksa kredensial.")
+
+    def build_requests_session(self) -> requests.Session:
+        if not self.context:
+            raise RuntimeError("Browser context belum tersedia")
+        session = requests.Session()
+        for cookie in self.context.cookies():
+            domain = cookie.get("domain", "")
+            session.cookies.set(
+                cookie["name"],
+                cookie["value"],
+                domain=domain.lstrip('.'),
+                path=cookie.get("path", "/"),
+            )
+        return session
+
+    # Pegawai listing -------------------------------------------------
+
+    def iter_pegawai_rows(self) -> Iterator[Dict[str, str]]:
+        if not self.page:
+            raise RuntimeError("Scraper not initialised")
+
+        listing_url = f"{self.base_url}/simpeg/#perekaman/data_pnscpns_v2"
+        self.page.goto(listing_url)
+        self.page.wait_for_selector("button.btn.btn-primary:has-text('Cari')")
+        self.page.click("button.btn.btn-primary:has-text('Cari')")
+        self.page.wait_for_selector("#dt_basiccari tbody tr")
+
+        rows = self.page.locator("#dt_basiccari tbody tr")
+        count = rows.count()
+        logger.info("Menemukan %s baris pegawai", count)
+        for index in range(count):
+            row = rows.nth(index)
+            anchor = row.locator("td:nth-child(2) a").first
+            onclick = anchor.get_attribute("onclick") or ""
+            match = re.search(r"cari\('(\d+)'\)", onclick)
+            if not match:
+                continue
+            pegawai_id = match.group(1)
+            nama = anchor.inner_text().strip()
+            nip = (row.locator("td").nth(2).inner_text().strip() or None)
+            yield {"id": pegawai_id, "nama": nama, "nip": nip}
+
+    # Training scraping -----------------------------------------------
+
+    def iter_training_records(
+        self,
+        pegawai_rows: Iterable[Dict[str, str]],
+        categories: Optional[List[str]] = None,
+    ) -> Iterator[SimpegTrainingRecord]:
+        if not self.page:
+            raise RuntimeError("Scraper not initialised")
+
+        categories = categories or list(TRAINING_TABS.keys())
+
+        for pegawai in pegawai_rows:
+            pegawai_id = pegawai["id"]
+            detail_url = f"{self.base_url}/simpeg/#perekaman/data_pnscpns_v2/{pegawai_id}"
+            logger.info("Memuat detail pegawai %s (%s)", pegawai_id, pegawai["nama"])
+            self.page.goto(detail_url)
+            try:
+                self.page.wait_for_selector("a[href='#hr3']")
+            except PlaywrightError:
+                logger.warning("Tidak dapat menemukan tab riwayat untuk %s", pegawai_id)
+                continue
+
+            self.page.click("a[href='#hr3']")
+            self.page.wait_for_timeout(500)
+
+            for category in categories:
+                tab = TRAINING_TABS.get(category)
+                if not tab:
+                    continue
+                try:
+                    self.page.click(tab["tab_selector"])
+                    self.page.wait_for_timeout(500)
+                except PlaywrightError:
+                    logger.warning("Tab %s tidak tersedia untuk pegawai %s", category, pegawai_id)
+                    continue
+
+                for record in self._scrape_training_table(tab, category, pegawai):
+                    yield record
+
+    def _scrape_training_table(
+        self,
+        tab_config: Dict[str, object],
+        category: str,
+        pegawai: Dict[str, str],
+    ) -> Iterator[SimpegTrainingRecord]:
+        if not self.page:
+            return
+
+        container_selector = tab_config.get("container")  # type: ignore[assignment]
+        if not isinstance(container_selector, str):
+            return
+
+        table_locator = self.page.locator(f"{container_selector} table tbody tr")
+        if table_locator.count() == 0:
+            return
+
+        column_map: Dict[str, Optional[int]] = tab_config.get("column_map", {})  # type: ignore[assignment]
+
+        for index in range(table_locator.count()):
+            row = table_locator.nth(index)
+            cells = [row.locator("td").nth(i).inner_text().strip() for i in range(row.locator("td").count())]
+
+            def get_cell(column: str) -> Optional[str]:
+                idx = column_map.get(column)
+                if idx is None or idx >= len(cells):
+                    return None
+                value = cells[idx].strip()
+                return value or None
+
+            sertifikat_link = row.locator("td a[target='_blank']").first
+            href = sertifikat_link.get_attribute("href") if sertifikat_link else None
+            if href and href.startswith("/"):
+                href = f"{self.base_url}{href}"
+
+            yield SimpegTrainingRecord(
+                pegawai_id=int(pegawai["id"]),
+                pegawai_nama=pegawai["nama"],
+                pegawai_nip=pegawai.get("nip"),
+                kategori=category,
+                induk_diklat=get_cell("induk_diklat"),
+                nama_pelatihan=get_cell("nama_pelatihan") or "",
+                tempat=get_cell("tempat"),
+                penyelenggara=get_cell("penyelenggara"),
+                tanggal_mulai=self._parse_date(get_cell("tanggal_mulai")),
+                tanggal_selesai=self._parse_date(get_cell("tanggal_selesai")),
+                jp=self._parse_int(get_cell("jp")),
+                nomor_sttp=get_cell("nomor_sttp"),
+                tanggal_sttp=self._parse_date(get_cell("tanggal_sttp")),
+                sertifikat_url=href,
+            )
+
+    @staticmethod
+    def _parse_date(value: Optional[str]) -> Optional[datetime.date]:
+        if not value or value in {"-", ""}:
+            return None
+        value = value.strip()
+        for fmt in ("%d-%m-%Y", "%Y-%m-%d", "%d/%m/%Y", "%d %B %Y"):
+            try:
+                return datetime.strptime(value, fmt).date()
+            except ValueError:
+                continue
+        return None
+
+    @staticmethod
+    def _parse_int(value: Optional[str]) -> Optional[int]:
+        if not value or value.strip() == "-":
+            return None
+        try:
+            return int(value.replace('.', '').strip())
+        except ValueError:
+            return None

--- a/tools/data_importer/data_importer/sql_writer.py
+++ b/tools/data_importer/data_importer/sql_writer.py
@@ -1,0 +1,236 @@
+"""Utility helpers for producing MySQL-compatible SQL scripts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+
+def _sql_literal(value) -> str:
+    """Return a SQL literal string for the provided Python value."""
+    if value is None:
+        return "NULL"
+
+    if isinstance(value, (datetime, date)):
+        return f"'{value.isoformat()}'"
+
+    if isinstance(value, Path):
+        value = value.as_posix()
+
+    text = str(value)
+    # Escape backslashes and single quotes for MySQL.
+    text = text.replace("\\", "\\\\").replace("'", "''")
+    return f"'{text}'"
+
+
+def _pegawai_condition(nama: str, nip: Optional[str]) -> str:
+    if nip:
+        return f"nip = {_sql_literal(nip)}"
+    return f"nama_lengkap = {_sql_literal(nama)}"
+
+
+def _pelatihan_exists_condition(
+    nama_pelatihan: str,
+    tanggal_mulai: Optional[date],
+    tanggal_selesai: Optional[date],
+) -> str:
+    conditions: List[str] = [
+        "pegawai_id = @pegawai_id",
+        f"nama_pelatihan = {_sql_literal(nama_pelatihan)}",
+    ]
+    if tanggal_mulai is None:
+        conditions.append("(tanggal_mulai IS NULL)")
+    else:
+        conditions.append(f"(tanggal_mulai = {_sql_literal(tanggal_mulai)})")
+    if tanggal_selesai is None:
+        conditions.append("(tanggal_selesai IS NULL)")
+    else:
+        conditions.append(f"(tanggal_selesai = {_sql_literal(tanggal_selesai)})")
+    return "\n      AND ".join(conditions)
+
+
+def build_training_sql_block(
+    *,
+    pegawai_nama: str,
+    pegawai_nip: Optional[str],
+    nama_pelatihan: str,
+    jenis_pelatihan: Optional[str],
+    penyelenggara: Optional[str],
+    tempat: Optional[str],
+    tanggal_mulai: Optional[date],
+    tanggal_selesai: Optional[date],
+    jp: Optional[int],
+    status: str,
+    deskripsi: Optional[str],
+    sertifikat_path: Optional[str],
+    jabatan: Optional[str] = None,
+    unit_kerja: Optional[str] = None,
+    keterangan: Optional[str] = None,
+) -> List[str]:
+    """Produce SQL statements required to insert or update one training record."""
+
+    condition = _pegawai_condition(pegawai_nama, pegawai_nip)
+    jp_value = str(jp or 0)
+
+    block: List[str] = []
+    block.append(
+        f"-- Data pelatihan untuk {pegawai_nama}{f' ({pegawai_nip})' if pegawai_nip else ''}"
+    )
+    block.append("SET @pegawai_id := NULL;")
+    block.append("SET @jenis_pelatihan_id := NULL;")
+
+    block.append(
+        """
+INSERT INTO pegawais
+    (nama_lengkap, nip, jabatan, unit_kerja, status, keterangan, jp_target, jp_tercapai, created_at, updated_at)
+SELECT
+    {nama}, {nip}, {jabatan}, {unit_kerja}, 'aktif', {keterangan}, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM DUAL
+WHERE NOT EXISTS (
+    SELECT 1 FROM pegawais WHERE {condition}
+);
+""".format(
+            nama=_sql_literal(pegawai_nama),
+            nip=_sql_literal(pegawai_nip) if pegawai_nip else "NULL",
+            jabatan=_sql_literal(jabatan) if jabatan else "NULL",
+            unit_kerja=_sql_literal(unit_kerja) if unit_kerja else "NULL",
+            keterangan=_sql_literal(keterangan) if keterangan else "NULL",
+            condition=condition,
+        ).strip()
+    )
+
+    block.append(
+        "SET @pegawai_id := (\n    SELECT id FROM pegawais\n     WHERE {condition}\n     ORDER BY id DESC\n     LIMIT 1\n);".format(
+            condition=condition,
+        )
+    )
+
+    if jenis_pelatihan:
+        block.append(
+            """
+INSERT INTO jenis_pelatihans (nama, created_at, updated_at)
+SELECT {nama}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM DUAL
+WHERE NOT EXISTS (
+    SELECT 1 FROM jenis_pelatihans WHERE nama = {nama}
+);
+""".format(
+                nama=_sql_literal(jenis_pelatihan)
+            ).strip()
+        )
+        block.append(
+            "SET @jenis_pelatihan_id := (\n    SELECT id FROM jenis_pelatihans\n     WHERE nama = {nama}\n     LIMIT 1\n);".format(
+                nama=_sql_literal(jenis_pelatihan)
+            )
+        )
+
+    block.append(
+        """
+INSERT INTO pelatihans
+    (pegawai_id, nama_pelatihan, jenis_pelatihan_id, penyelenggara, tempat, tanggal_mulai, tanggal_selesai, jp, status, sertifikat_path, deskripsi, created_at, updated_at)
+SELECT
+    @pegawai_id,
+    {nama_pelatihan},
+    {jenis_id},
+    {penyelenggara},
+    {tempat},
+    {tanggal_mulai},
+    {tanggal_selesai},
+    {jp},
+    {status},
+    {sertifikat},
+    {deskripsi},
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+FROM DUAL
+WHERE @pegawai_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM pelatihans
+       WHERE {exists_condition}
+  );
+""".format(
+            nama_pelatihan=_sql_literal(nama_pelatihan),
+            jenis_id="@jenis_pelatihan_id" if jenis_pelatihan else "NULL",
+            penyelenggara=_sql_literal(penyelenggara) if penyelenggara else "NULL",
+            tempat=_sql_literal(tempat) if tempat else "NULL",
+            tanggal_mulai=_sql_literal(tanggal_mulai) if tanggal_mulai else "NULL",
+            tanggal_selesai=_sql_literal(tanggal_selesai) if tanggal_selesai else "NULL",
+            jp=jp_value,
+            status=_sql_literal(status),
+            sertifikat=_sql_literal(sertifikat_path) if sertifikat_path else "NULL",
+            deskripsi=_sql_literal(deskripsi) if deskripsi else "NULL",
+            exists_condition=_pelatihan_exists_condition(
+                nama_pelatihan,
+                tanggal_mulai,
+                tanggal_selesai,
+            ),
+        ).strip()
+    )
+
+    block.append(
+        """
+UPDATE pegawais
+   SET jp_tercapai = (
+           SELECT COALESCE(SUM(jp), 0)
+             FROM pelatihans
+            WHERE pelatihans.pegawai_id = pegawais.id
+              AND status = 'selesai'
+       ),
+       updated_at = CURRENT_TIMESTAMP
+ WHERE id = @pegawai_id
+   AND @pegawai_id IS NOT NULL;
+""".strip()
+    )
+
+    block.append("")
+    return block
+
+
+@dataclass
+class SqlScriptBuilder:
+    output_path: Path
+    lines: List[str] = field(default_factory=list)
+    _finalized: bool = False
+
+    def __post_init__(self) -> None:
+        timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        self.lines.extend(
+            [
+                f"-- Generated by SIDIKLAT importer on {timestamp} UTC",
+                "SET NAMES utf8mb4;",
+                "SET FOREIGN_KEY_CHECKS = 0;",
+                "START TRANSACTION;",
+                "",
+            ]
+        )
+
+    def add_block(self, statements: Sequence[str]) -> None:
+        if self._finalized:
+            raise RuntimeError("Cannot add statements after the script has been finalized")
+        for stmt in statements:
+            if stmt:
+                self.lines.append(stmt)
+        if statements and statements[-1] != "":
+            self.lines.append("")
+
+    def finalize(self) -> None:
+        if self._finalized:
+            return
+        self.lines.extend([
+            "COMMIT;",
+            "SET FOREIGN_KEY_CHECKS = 1;",
+            "",
+        ])
+        self._finalized = True
+
+    def save(self) -> Path:
+        self.finalize()
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        content = "\n".join(self.lines).rstrip() + "\n"
+        self.output_path.write_text(content, encoding="utf-8")
+        return self.output_path
+
+    def __str__(self) -> str:
+        return "\n".join(self.lines)

--- a/tools/data_importer/data_importer/utils.py
+++ b/tools/data_importer/data_importer/utils.py
@@ -1,0 +1,48 @@
+"""Utility helpers for the importer."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from pathlib import Path
+from typing import Optional
+
+
+def slugify(value: str, allow_unicode: bool = False) -> str:
+    value = str(value)
+    if allow_unicode:
+        value = unicodedata.normalize('NFKC', value)
+    else:
+        value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
+    value = re.sub(r'[^\w\s-]', '', value).strip().lower()
+    return re.sub(r'[-\s]+', '-', value)
+
+
+def ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def shorten_filename(base_name: str, max_length: int = 80) -> str:
+    if len(base_name) <= max_length:
+        return base_name
+    stem, dot, suffix = base_name.partition('.')
+    trimmed_stem = stem[: max_length - len(suffix) - 1]
+    return f"{trimmed_stem}{dot}{suffix}" if suffix else trimmed_stem
+
+
+def build_certificate_filename(nama: str, pelatihan: str, extension: str = "pdf") -> str:
+    nama_slug = slugify(nama)
+    pelatihan_slug = slugify(pelatihan)
+    filename = f"{nama_slug}-{pelatihan_slug}.{extension.strip('.')}"
+    return shorten_filename(filename)
+
+
+def guess_extension_from_content_type(content_type: Optional[str]) -> str:
+    if not content_type:
+        return "pdf"
+    mapping = {
+        "application/pdf": "pdf",
+        "image/jpeg": "jpg",
+        "image/png": "png",
+    }
+    return mapping.get(content_type.lower(), "pdf")

--- a/tools/data_importer/requirements.txt
+++ b/tools/data_importer/requirements.txt
@@ -1,0 +1,6 @@
+mysql-connector-python
+openpyxl
+playwright
+python-dotenv
+requests
+typer


### PR DESCRIPTION
## Summary
- add a reusable SQL script builder that produces idempotent INSERT/UPDATE statements for pegawai, jenis, and pelatihan records
- extend the Excel and SIMPEG import commands with an optional `--sql-output` flag that writes the processed data to a MySQL-ready .sql file while keeping the direct-to-DB workflow intact
- document the new export mode in the importer README, noting when database credentials are optional and providing example commands

## Testing
- python -m compileall tools/data_importer/data_importer

------
https://chatgpt.com/codex/tasks/task_b_68de9ecdf0a883248c7ce009592b5784