### PR TITLE
Update data importer README with GUI instructions

### DIFF
--- a/tools/data_importer/README.md
+++ b/tools/data_importer/README.md
@@ -34,7 +34,9 @@ tools/data_importer/
    playwright install chromium
    ```
 
-3. Salin variabel koneksi database dan kredensial SIMPEG ke environment. Contoh menggunakan file `.env` pada root proyek Laravel. Variabel database hanya diperlukan jika Anda ingin langsung menulis ke database, bukan ketika menghasilkan berkas `.sql`:
+3. (Opsional) Untuk menjalankan antarmuka grafis berbasis Tkinter pastikan sistem operasi memiliki pustaka GUI yang diperlukan (mis. `tk`/`python3-tk` di Linux).
+
+4. Salin variabel koneksi database dan kredensial SIMPEG ke environment. Contoh menggunakan file `.env` pada root proyek Laravel. Variabel database hanya diperlukan jika Anda ingin langsung menulis ke database, bukan ketika menghasilkan berkas `.sql`:
 
    ```dotenv
    SIDIKLAT_DB_HOST=127.0.0.1
@@ -59,6 +61,12 @@ Jalankan CLI dengan perintah berikut dari root repository:
 
 ```bash
 python -m data_importer --help
+```
+
+Jika ingin melihat daftar perintah dari antarmuka grafis, jalankan:
+
+```bash
+python -m data_importer gui
 ```
 
 ### Impor dari Excel
@@ -90,6 +98,16 @@ Untuk menghasilkan skrip SQL tanpa menyentuh database:
 ```bash
 python -m data_importer import-excel data/daftar_pelatihan.xlsx --sheet "Sheet1" --sql-output output/pelatihan_excel.sql
 ```
+
+### Antarmuka Grafis (GUI)
+
+Gunakan perintah berikut untuk membuka antarmuka grafis sederhana yang memudahkan pemilihan berkas Excel, nama sheet, dan tujuan keluaran SQL:
+
+```bash
+python -m data_importer gui
+```
+
+Melalui GUI, proses impor dijalankan di thread terpisah sehingga jendela tetap responsif. Status keberhasilan atau kegagalan akan ditampilkan melalui dialog.
 
 ### Impor dari SIMPEG
 

--- a/tools/data_importer/data_importer/cli.py
+++ b/tools/data_importer/data_importer/cli.py
@@ -90,16 +90,12 @@ def _store_excel_row(
     )
 
 
-@app.command("import-excel")
-def import_excel(
-    excel_path: Path = typer.Argument(..., exists=True, dir_okay=False, help="Path file Excel sumber."),
-    sheet_name: Optional[str] = typer.Option(None, help="Nama sheet yang akan dibaca."),
-    sql_output: Optional[Path] = typer.Option(
-        None,
-        help="Jika diset, data tidak langsung dimasukkan ke database melainkan ditulis ke file SQL ini.",
-    ),
+def import_excel_data(
+    excel_path: Path,
+    sheet_name: Optional[str] = None,
+    sql_output: Optional[Path] = None,
 ) -> None:
-    """Impor data pelatihan dari berkas Excel."""
+    """Core routine for importing Excel data."""
 
     config = AppConfig.load()
     loader = ExcelLoader()
@@ -121,6 +117,20 @@ def import_excel(
                 _store_excel_row(row, downloader, certificate_root, client=client)
 
     logger.info("Import Excel selesai.")
+
+
+@app.command("import-excel")
+def import_excel(
+    excel_path: Path = typer.Argument(..., exists=True, dir_okay=False, help="Path file Excel sumber."),
+    sheet_name: Optional[str] = typer.Option(None, help="Nama sheet yang akan dibaca."),
+    sql_output: Optional[Path] = typer.Option(
+        None,
+        help="Jika diset, data tidak langsung dimasukkan ke database melainkan ditulis ke file SQL ini.",
+    ),
+) -> None:
+    """Impor data pelatihan dari berkas Excel."""
+
+    import_excel_data(excel_path, sheet_name=sheet_name, sql_output=sql_output)
 
 
 CATEGORY_LABELS = {
@@ -257,6 +267,15 @@ def import_simpeg(
                     )
 
     logger.info("Import SIMPEG selesai.")
+
+
+@app.command("gui")
+def open_gui() -> None:
+    """Buka antarmuka grafis untuk impor data."""
+
+    from .gui import launch_gui
+
+    launch_gui()
 
 
 def run():  # pragma: no cover - CLI entry point

--- a/tools/data_importer/data_importer/gui.py
+++ b/tools/data_importer/data_importer/gui.py
@@ -1,0 +1,175 @@
+"""Simple GUI wrapper for the SIDIKLAT data importer."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from pathlib import Path
+from typing import Optional
+
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+from .cli import import_excel_data
+
+
+class ImporterGUI:
+    """Tkinter based GUI to import Excel files."""
+
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("SIDIKLAT Data Importer")
+        self.root.geometry("520x240")
+        self.root.resizable(False, False)
+
+        self.excel_path_var = tk.StringVar()
+        self.sheet_name_var = tk.StringVar()
+        self.use_sql_var = tk.BooleanVar(value=False)
+        self.sql_path_var = tk.StringVar()
+        self.status_var = tk.StringVar(value="Pilih file Excel untuk mulai.")
+
+        self._queue: queue.Queue[tuple[str, str]] = queue.Queue()
+        self._thread: Optional[threading.Thread] = None
+
+        self._build_widgets()
+
+    def _build_widgets(self) -> None:
+        padding = {"padx": 12, "pady": 6}
+
+        excel_frame = ttk.LabelFrame(self.root, text="Sumber Excel")
+        excel_frame.pack(fill="x", **padding)
+
+        excel_row = ttk.Frame(excel_frame)
+        excel_row.pack(fill="x", padx=8, pady=6)
+
+        ttk.Label(excel_row, text="File Excel:").pack(side="left")
+        entry = ttk.Entry(excel_row, textvariable=self.excel_path_var, width=45)
+        entry.pack(side="left", padx=(6, 6))
+        ttk.Button(excel_row, text="Browse...", command=self._browse_excel).pack(side="left")
+
+        sheet_row = ttk.Frame(excel_frame)
+        sheet_row.pack(fill="x", padx=8, pady=(0, 6))
+        ttk.Label(sheet_row, text="Sheet (opsional):").pack(side="left")
+        ttk.Entry(sheet_row, textvariable=self.sheet_name_var, width=20).pack(side="left", padx=(6, 0))
+
+        sql_frame = ttk.LabelFrame(self.root, text="Output SQL (opsional)")
+        sql_frame.pack(fill="x", **padding)
+
+        sql_toggle = ttk.Checkbutton(
+            sql_frame,
+            text="Simpan ke file SQL",
+            variable=self.use_sql_var,
+            command=self._toggle_sql_entry,
+        )
+        sql_toggle.pack(anchor="w", padx=8, pady=(6, 0))
+
+        sql_row = ttk.Frame(sql_frame)
+        sql_row.pack(fill="x", padx=8, pady=(0, 6))
+
+        self.sql_entry = ttk.Entry(sql_row, textvariable=self.sql_path_var, width=45, state="disabled")
+        self.sql_entry.pack(side="left")
+        self.sql_button = ttk.Button(sql_row, text="Simpan Sebagai...", command=self._browse_sql, state="disabled")
+        self.sql_button.pack(side="left", padx=(6, 0))
+
+        action_frame = ttk.Frame(self.root)
+        action_frame.pack(fill="x", **padding)
+
+        self.import_button = ttk.Button(action_frame, text="Mulai Import", command=self._start_import)
+        self.import_button.pack(side="right")
+
+        status_label = ttk.Label(self.root, textvariable=self.status_var, foreground="#555555")
+        status_label.pack(anchor="w", padx=16, pady=(0, 12))
+
+    def _browse_excel(self) -> None:
+        filename = filedialog.askopenfilename(
+            title="Pilih berkas Excel",
+            filetypes=[("Excel Files", "*.xlsx *.xlsm *.xls"), ("All Files", "*.*")],
+        )
+        if filename:
+            self.excel_path_var.set(filename)
+
+    def _browse_sql(self) -> None:
+        filename = filedialog.asksaveasfilename(
+            title="Pilih lokasi output SQL",
+            defaultextension=".sql",
+            filetypes=[("SQL Files", "*.sql"), ("All Files", "*.*")],
+        )
+        if filename:
+            self.sql_path_var.set(filename)
+
+    def _toggle_sql_entry(self) -> None:
+        state = "normal" if self.use_sql_var.get() else "disabled"
+        self.sql_entry.configure(state=state)
+        self.sql_button.configure(state=state)
+
+    def _start_import(self) -> None:
+        excel_path = Path(self.excel_path_var.get()).expanduser()
+        if not excel_path.exists():
+            messagebox.showerror("Kesalahan", "File Excel belum dipilih atau tidak ditemukan.")
+            return
+
+        sql_output: Optional[Path] = None
+        if self.use_sql_var.get():
+            sql_value = self.sql_path_var.get().strip()
+            if not sql_value:
+                messagebox.showerror("Kesalahan", "Lokasi file SQL harus diisi atau nonaktifkan opsi SQL.")
+                return
+            sql_output = Path(sql_value).expanduser()
+
+        sheet_name = self.sheet_name_var.get().strip() or None
+
+        if self._thread and self._thread.is_alive():
+            messagebox.showwarning("Sedang Berjalan", "Proses import masih berjalan.")
+            return
+
+        self.status_var.set("Memulai proses import...")
+        self.import_button.configure(state="disabled")
+
+        def runner() -> None:
+            try:
+                import_excel_data(excel_path, sheet_name=sheet_name, sql_output=sql_output)
+            except Exception as exc:  # noqa: BLE001
+                self._queue.put(("error", str(exc)))
+            else:
+                if sql_output:
+                    message = f"Selesai. SQL tersimpan di {sql_output}."
+                else:
+                    message = "Import Excel selesai ke database."
+                self._queue.put(("success", message))
+
+        self._thread = threading.Thread(target=runner, daemon=True)
+        self._thread.start()
+        self.root.after(200, self._poll_queue)
+
+    def _poll_queue(self) -> None:
+        try:
+            status, message = self._queue.get_nowait()
+        except queue.Empty:
+            if self._thread and self._thread.is_alive():
+                self.root.after(200, self._poll_queue)
+            else:
+                self.import_button.configure(state="normal")
+                self.status_var.set("Siap.")
+            return
+
+        self.import_button.configure(state="normal")
+        self.status_var.set(message)
+
+        if status == "error":
+            messagebox.showerror("Gagal", message)
+        else:
+            messagebox.showinfo("Berhasil", message)
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+def launch_gui() -> None:
+    """Launch the data importer GUI."""
+
+    gui = ImporterGUI()
+    gui.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    launch_gui()


### PR DESCRIPTION
## Summary
- add a setup note for Tkinter so the new GUI can run on supported systems
- document the `gui` command in the usage section of the data importer README
- describe the GUI workflow for choosing Excel files and optional SQL output

## Testing
- ⚠️ `PYTHONPATH=tools/data_importer python -m data_importer --help` *(fails because typer dependency is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68deb5978708832495a952a0514f58f8